### PR TITLE
Add kerberos to actionrunner

### DIFF
--- a/st2actionrunner/Dockerfile
+++ b/st2actionrunner/Dockerfile
@@ -6,7 +6,9 @@ LABEL com.stackstorm.component="st2actionrunner"
 RUN apt-get install -y rsync \
   inetutils-traceroute \
   net-tools \
-  dnsutils
+  dnsutils \
+  gcc \
+  libkrb5-dev
 
 USER root
 


### PR DESCRIPTION
Extended actionrunner image with kerberos to work with Active Directory.